### PR TITLE
Return NA if either sd in the denominator is 0.

### DIFF
--- a/src/sliding_cor_c.cpp
+++ b/src/sliding_cor_c.cpp
@@ -11,7 +11,7 @@ NumericVector sliding_cor_c(NumericVector shortvec, NumericVector longvec, doubl
   int out_length = length_longvec - n_minus1;
   if (sd_shortvec < sqrt(DBL_EPSILON)) {
     NumericVector out(out_length, NA_REAL);
-    return(out);
+    return out;
   }
   NumericVector out(out_length);
   

--- a/src/sliding_cor_c.cpp
+++ b/src/sliding_cor_c.cpp
@@ -9,6 +9,10 @@ NumericVector sliding_cor_c(NumericVector shortvec, NumericVector longvec, doubl
   int n = shortvec.size();
   int n_minus1 = n - 1;
   int out_length = length_longvec - n_minus1;
+  if (sd_shortvec < sqrt(DBL_EPSILON)) {
+    NumericVector out(out_length, NA_REAL);
+    return(out);
+  }
   NumericVector out(out_length);
   
   // Calculate constant term to multiply all 
@@ -37,7 +41,11 @@ NumericVector sliding_cor_c(NumericVector shortvec, NumericVector longvec, doubl
       ss_longvec_current += pow(longvec_current_b - mean_longvec_current, 2);
     }
     double sd_longvec_current = sqrt(ss_longvec_current / n_minus1);
-    out[a] = (sum_products / n_minus1 - sum_longvec_current * term2) / sd_shortvec / sd_longvec_current;
+    if (sd_longvec_current < sqrt(DBL_EPSILON)) {
+      out[a] = NA_REAL;
+    } else {
+      out[a] = (sum_products / n_minus1 - sum_longvec_current * term2) / sd_shortvec / sd_longvec_current;
+    }
   }
   return out;
 }


### PR DESCRIPTION
Fixes #1.

Checks if the standard deviations are close to 0 and returns NA if so, since otherwise would be dividing by 0.
Threshold I'm using is about 1.49e-8, which is based on the same threshold used by dplyr's [`near()`](https://dplyr.tidyverse.org/reference/near.html)

```
> devtools::load_all()
ℹ Loading dvmisc
> set.seed(87)
> dvmisc::sliding_cor(runif(25), rep(1.014103, 40))
 [1] NA NA NA NA NA NA NA NA NA NA NA NA NA NA NA NA
> set.seed(100)
> dvmisc::sliding_cor(runif(25), rep(1.014103, 40)) 
 [1] NA NA NA NA NA NA NA NA NA NA NA NA NA NA NA NA
> set.seed(100)
> dvmisc::sliding_cor(runif(30), rep(1.014103, 40)) 
 [1] NA NA NA NA NA NA NA NA NA NA NA
> set.seed(100)
> dvmisc::sliding_cor(runif(20), rep(1.014103, 40))
 [1] NA NA NA NA NA NA NA NA NA NA NA NA NA NA NA NA NA NA NA NA NA
> set.seed(100)
> dvmisc::sliding_cor(rep(1.014103, 40), runif(50))
 [1] NA NA NA NA NA NA NA NA NA NA NA
```
(Included one additional example at the end if sd_shortvec is ~0, not just longvec).

